### PR TITLE
added 'isprimary' to photoset

### DIFF
--- a/acf-flickr-v5.php
+++ b/acf-flickr-v5.php
@@ -742,6 +742,7 @@ class acf_field_flickr extends acf_field {
 						$sets[$id][$photo['id']]['thumb']    = $f->buildPhotoURL($photo, $value['thumb_size']);
 						$sets[$id][$photo['id']]['large']    = ($value['large_size'] == 'original') ? $photo['url_o'] : $f->buildPhotoURL($photo, $value['large_size']);
 						$sets[$id][$photo['id']]['photo_id'] = $photo['id'];
+						$sets[$id][$photo['id']]['isprimary'] = (isset($photo['isprimary'])) ? $photo['isprimary'] : 0;
 					}
 				}
 				$value['items'] = $sets;


### PR DESCRIPTION
I needed to know the photo in the photo set that was set as primary. 

As this was already in the response of the Flickr API, I added the 'isprimary' element to the `$sets` array 
